### PR TITLE
Skip test on threaded OpenBSD

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ t/IPC-Run3-ProfPP.t
 t/IPC-Run3-ProfReporter.t
 t/IPC-Run3-profiling.t
 t/IPC-Run3.t
+t/die_handler.t
 t/fd_leak.t
 t/fork.t
 t/pod-coverage.t

--- a/t/IPC-Run3.t
+++ b/t/IPC-Run3.t
@@ -205,19 +205,28 @@ sub {
 # check that run3 doesn't die on platforms where system()
 # returns -1 when SIGCHLD is ignored (RT #14272)
 sub {
-    my $system_child_error = eval
-    {
-	local $SIG{CHLD} = "IGNORE";
-	system $^X, '-e', 0;
-	$?;
-    };
-    my $run3_child_error = eval
-    {
-	local $SIG{CHLD} = "IGNORE";
-	run3 [ $^X, '-e', 0 ], \undef, \undef, \undef, { return_if_system_error => 1 };
-	$?;
-    };
-    ok $run3_child_error, $system_child_error;
+  use Config;
+
+  if ( $^O eq 'openbsd' and $Config{'useithreads'} ) {
+    ok(1); # Bug in OpenBSD threaded perls causes a hang
+  }
+  else {
+
+      my $system_child_error = eval
+      {
+	      local $SIG{CHLD} = "IGNORE";
+	      system $^X, '-e', 0;
+	      $?;
+      };
+      my $run3_child_error = eval
+      {
+	      local $SIG{CHLD} = "IGNORE";
+	      run3 [ $^X, '-e', 0 ], \undef, \undef, \undef, { return_if_system_error => 1 };
+	      $?;
+      };
+      ok $run3_child_error, $system_child_error;
+
+  }
 },
 );
 


### PR DESCRIPTION
One of the tests in IPC-Run3.t exposes a bug in threaded
OpenBSD perls causing the test to hang indefinitely.

Confirmed with all perls from v5.8.9 through to v5.14.3
