### PR TITLE
Fix test 26 on Win XP

### DIFF
--- a/t/IPC-Run3.t
+++ b/t/IPC-Run3.t
@@ -177,6 +177,7 @@ sub {
 
 sub {
     my $fn = "t/test.txt";
+    unlink $fn or warn "$! unlinking $fn" if -e $fn;
     open FH, ">", $fn or warn "$! opening $fn";
 
     ( $in, $out, $err ) = ();


### PR DESCRIPTION
Running this test on Windows XP SP3 with Strawberry Perl v5.16.3, I get the following test failure:

```
not ok 26
# Test 26 got: "8" (t\IPC-Run3.t at line 186)
#    Expected: "3"
#  t\IPC-Run3.t line 186 is:     ok -s $fn, 3;
```

Looking at the file test.txt, I see it contains the string `OUTFFOUT`. I don't yet see _why_ this happens, but this proposed change (unlinking the file before the test) fixes the problem...
