### PR TITLE
add checks for errno on windows

### DIFF
--- a/lib/IPC/Run3.pm
+++ b/lib/IPC/Run3.pm
@@ -399,7 +399,7 @@ sub run3 {
 
         $sys_call_time = gettimeofday() if profiling;
         
-        $! = 0;
+        $! = 0;                  # make sure we don't test below against some previous error
 
         my $r = ref $cmd
               ? system { $cmd->[0] } is_win32 ? quote_native( @$cmd ) : @$cmd

--- a/lib/IPC/Run3.pm
+++ b/lib/IPC/Run3.pm
@@ -398,6 +398,8 @@ sub run3 {
             if defined $err_fh;
 
         $sys_call_time = gettimeofday() if profiling;
+        
+        $! = 0;
 
         my $r = ref $cmd
               ? system { $cmd->[0] } is_win32 ? quote_native( @$cmd ) : @$cmd
@@ -416,7 +418,7 @@ sub run3 {
 
         if (
             defined $r
-            && ( $r == -1 || ( is_win32 && $r == 0xFF00 ) )
+            && ( $r == -1 || ( is_win32 && $r == 0xFF00 && $errno != 0 ) )
             && !$options->{return_if_system_error}
         ) {
             croak( $errno );

--- a/t/IPC-Run3.t
+++ b/t/IPC-Run3.t
@@ -228,6 +228,13 @@ sub {
 
   }
 },
+
+
+sub {
+  my($in, $out, $err) = ();
+  eval { run3 [ $^X, '-e', 'BEGIN { die }' ], \$in, \$out, \$err };
+  ok $@, '';
+}
 );
 
 plan tests => 0+@tests;

--- a/t/IPC-Run3.t
+++ b/t/IPC-Run3.t
@@ -231,10 +231,29 @@ sub {
 
 
 sub {
-  my($in, $out, $err) = ();
+  ($in, $out, $err) = ();
   eval { run3 [ $^X, '-e', 'BEGIN { die }' ], \$in, \$out, \$err };
   ok $@, '';
-}
+},
+
+sub {
+  ($in, $out, $err) = ();
+  eval { run3 [ $^X, '-e', 'print STDOUT "stdout"; print STDERR "stderr"; exit 255;' ], \$in, \$out, \$err };
+  ok $@, '';
+},
+
+sub {
+  ok $out, "stdout";
+},
+
+sub {
+  ok $err, "stderr";
+},
+
+sub {
+  ok $? >> 8, 255;
+},
+
 );
 
 plan tests => 0+@tests;


### PR DESCRIPTION
This PR applies the patch mentioned in rt95308.  I can't claim credit for it for the patch, but it appears to fix a problem that manifests itself in `Test::Script` and `Test::Script::Run` on Windows.  I have tested on the former to verify that it fixes this bug:

https://github.com/plicease/Test-Script/issues/1

If you think an alternate solution would be preferable I am happy to test it out if you don't have a windows handy.
